### PR TITLE
Implement fuzzy search.

### DIFF
--- a/app/views/pages/RuleListPageView/style.styl
+++ b/app/views/pages/RuleListPageView/style.styl
@@ -20,4 +20,9 @@
     &__item-description {
         margin-top: -10px;
     }
+
+    em {
+        font-style: normal;
+        font-weight bold;
+    }
 }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "extract-text-webpack-plugin": "^0.7.1",
     "file-loader": "^0.8.1",
     "flux": "^2.0.3",
+    "fuzzy": "^0.1.1",
     "highlight.js": "^8.4.0",
     "jscs": "^2.3.4",
     "marked": "^0.3.2",


### PR DESCRIPTION
@hzoo, please, consider my implementation of rules fuzzy search.
Here I run fuzzy search twice — first on rules name, second (among rules that didn't hit on the first run) on rules summary. Then I show two groups of matched rules together, with name matched on top. Here I tried to preserve original logic, but made it little more sane. Unfortunately, I am able to highlight only name, not summary, because of summary often contains markup. 
